### PR TITLE
Replaced size calculation with a more optimal version

### DIFF
--- a/filtercascade/__init__.py
+++ b/filtercascade/__init__.py
@@ -73,8 +73,6 @@ class Bloomer:
     def calc_size(cls, nHashFuncs, elements, falsePositiveRate):
         # From CRLite paper, https://cbw.sh/static/pdf/larisch-oakland17.pdf
         return math.ceil(1.44 * elements * math.log(1 / falsePositiveRate, 2))
-        #return math.ceil(1 - (nHashFuncs * (elements + 0.5) / math.log(
-        #    1 - (math.pow(falsePositiveRate, (1 / nHashFuncs))))))
 
     @classmethod
     def from_buf(cls, buf):

--- a/filtercascade/__init__.py
+++ b/filtercascade/__init__.py
@@ -67,12 +67,14 @@ class Bloomer:
 
     @classmethod
     def calc_n_hashes(cls, falsePositiveRate):
-        return math.ceil(math.log(1.0 / falsePositiveRate) / math.log(2))
+        return math.ceil(math.log(1.0 / falsePositiveRate, 2))
 
     @classmethod
     def calc_size(cls, nHashFuncs, elements, falsePositiveRate):
-        return math.ceil(1 - (nHashFuncs * (elements + 0.5) / math.log(
-            1 - (math.pow(falsePositiveRate, (1 / nHashFuncs))))))
+        # From CRLite paper, https://cbw.sh/static/pdf/larisch-oakland17.pdf
+        return math.ceil(1.44 * elements * math.log(1 / falsePositiveRate, 2))
+        #return math.ceil(1 - (nHashFuncs * (elements + 0.5) / math.log(
+        #    1 - (math.pow(falsePositiveRate, (1 / nHashFuncs))))))
 
     @classmethod
     def from_buf(cls, buf):
@@ -96,11 +98,12 @@ class Bloomer:
 class FilterCascade:
     DIFF_FMT = b'<III'
 
-    def __init__(self, filters, error_rates=[0.02, 0.5], version=0):
+    def __init__(self, filters, error_rates=[0.02, 0.5], growth_factor=1.1,
+                 min_filter_length=10000, version=0):
         self.filters = filters
         self.error_rates = error_rates
-        self.growth_factor = 1.1
-        self.min_filter_length = 10000
+        self.growth_factor = growth_factor
+        self.min_filter_length = min_filter_length
         self.version = version
 
     def initialize(self, *, include, exclude):


### PR DESCRIPTION
I'm not sure what the origin of the calc_size() formulation used in this implementation was, but it's a bit sub-optimal. Here are some plots showing the size of the existing "Moz" bloom filters versus the 1.44*n*log_2(1/p) formulation from the CRLite paper:

![results](https://user-images.githubusercontent.com/8768998/60976958-9bbfb000-a2fc-11e9-8671-66946e978a89.png)

All three plots show how filters using the two size formulas vary as the number of elements (n) and false positive rate (FPR, p) vary. The top graph is total filter sizes in bits, the middle graph is difference in size in bits, and the bottom graph is percentage increase in size.

Depending on how things work out with math.ceil(), the existing formulation produces filters that are 0-5% oversized. 

I also added some additional, optional parameters to the filter cascade constructor, so downstream users can parameterize the free space overhead and minimum filter sizes.