### PR TITLE
Add SHA256 and Salt support

### DIFF
--- a/filtercascade/test.py
+++ b/filtercascade/test.py
@@ -126,6 +126,20 @@ class TestFilterCascade(unittest.TestCase):
         self.assertEqual(f.filters[1].size, 14400)
         self.assertEqual(f.filters[2].size, 14400)
 
+    def test_verify_failure(self):
+        """
+        This test cheats, changing the corpus of data out from under the Bloom
+        filter. Not every such change would raise an AssertionError,
+        particularly on these small data-sets.
+        """
+        fc = filtercascade.FilterCascade([])
+
+        valid, revoked = get_serial_sets(num_valid=10, num_revoked=1)
+        fc.initialize(include=revoked, exclude=valid)
+
+        with self.assertRaises(AssertionError):
+            valid2, revoked2 = get_serial_sets(num_valid=10, num_revoked=2)
+            fc.verify(include=revoked2, exclude=valid2)
 
 class TestFilterCascadeSalts(unittest.TestCase):
     def test_non_byte_salt(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 bitarray >= 0.9.2
+Deprecated >= 1.2
 mmh3 >= 2.5.1


### PR DESCRIPTION
I'm particularly interested in your thoughts on the composition order for the sha256 updates, and whether you think I should go ahead and add support via concatenation for salts to murmurhash. I would note as-is, we _would_ construct a salted murmurhash3 as:
`mmh3(salt || key, hash_seed)`
whereas the construction for sha256 is here:
`sha256(salt || hash_seed || key)`
and recall `hash_seed` from the paper is basically the layer number shifted left.

Apologies for the formatting changes in there - `Black` did that when the arg lists got longer.