### PR TITLE
Add a method set_crlite_error_rates

### DIFF
--- a/filtercascade/__init__.py
+++ b/filtercascade/__init__.py
@@ -236,6 +236,14 @@ class FilterCascade:
         if self.salt and self.hashAlg == HashAlgorithm.MURMUR3:
             raise ValueError("salts not permitted for MurmurHash3")
 
+    def set_crlite_error_rates(self, *, include_len, exclude_len):
+        if include_len > exclude_len:
+            raise InvertedLogicException(
+                depth=None, exclude_count=exclude_len, include_len=include_len
+            )
+        self.error_rates = [include_len / (math.sqrt(2) * exclude_len), 0.5]
+        return self.error_rates
+
     def initialize(self, *, include, exclude):
         """
             Arg "exclude" is potentially larger than main memory, so it should

--- a/filtercascade/test.py
+++ b/filtercascade/test.py
@@ -285,6 +285,16 @@ class TestFilterCascadeSalts(unittest.TestCase):
                 version=1,
             )
 
+    def test_expected_error_rates(self):
+        fc = filtercascade.FilterCascade([])
+        result = fc.set_crlite_error_rates(include_len=50, exclude_len=1_000)
+        self.assertAlmostEqual(result[0], 0.0353, places=3)
+        self.assertEqual(result[1], 0.5)
+        self.assertEqual(result, fc.error_rates)
+
+        with self.assertRaises(filtercascade.InvertedLogicException):
+            fc.set_crlite_error_rates(include_len=1_000, exclude_len=50)
+
 
 class TestFilterCascadeAlgorithms(unittest.TestCase):
     def verify_minimum_sets(self, *, hashAlg):


### PR DESCRIPTION
This adds a convenience method for calculating the error rates array based on the CRLite paper's formula.