### PR TITLE
Integration fixes - SHA256, Format v2, and inversion

### DIFF
--- a/filtercascade/__init__.py
+++ b/filtercascade/__init__.py
@@ -409,7 +409,6 @@ class FilterCascade:
     def from_buf(cls, buf):
         inverted = False
         salt = None
-        hashAlg = None
 
         (version,) = fileformats.version_struct.unpack(
             buf[: fileformats.version_struct.size]

--- a/filtercascade/fileformats.py
+++ b/filtercascade/fileformats.py
@@ -1,5 +1,14 @@
 import struct
 
+from enum import IntEnum, unique
+
+
+@unique
+class HashAlgorithm(IntEnum):
+    MURMUR3 = 1
+    SHA256 = 2
+
+
 # The header for each Bloom filter level
 # Little endian (<)
 # byte 0: Hash algorithm enumeration, as an unsigned char

--- a/filtercascade/fileformats.py
+++ b/filtercascade/fileformats.py
@@ -1,0 +1,28 @@
+import struct
+
+# The header for each Bloom filter level
+# Little endian (<)
+# byte 0: Hash algorithm enumeration, as an unsigned char
+# bytes 1-4: L, length of the bitarray, in bytes, as an unsigned int
+# bytes 5-8: the number of hash functions for this layer, as an unsigned int
+# byte 9: The layer number of this bloom filter, as an unsigned char
+bloomer_struct = struct.Struct(b"<BIIB")
+
+# This struct packs the hash iteration number and the layer number
+# into two bytes in a defined way for SHA256.
+# byte 0: hash iteration number as an unsigned char
+# byte 1: layer number of this bloom filter, as an unsigned char
+bloomer_sha256_hash_struct = struct.Struct(b"<BB")
+
+# The version struct is a simple 2-byte short indicating version number
+# Little endian (<)
+# bytes 0-1: The version number of this filter, as an unsigned short
+version_struct = struct.Struct(b"<H")
+
+# version 2 filters, after the version_struct field, have
+# the following:
+# Little endian (<)
+# byte 0: Whether the decision logic should be inverted, as a boolean
+# byte 1: L, length of salt field as a unsigned char
+# bytes 2+: salt field of length L
+version_2_salt_struct = struct.Struct(b"<?B")

--- a/filtercascade/fileformats.py
+++ b/filtercascade/fileformats.py
@@ -10,9 +10,10 @@ bloomer_struct = struct.Struct(b"<BIIB")
 
 # This struct packs the hash iteration number and the layer number
 # into two bytes in a defined way for SHA256.
-# byte 0: hash iteration number as an unsigned char
-# byte 1: layer number of this bloom filter, as an unsigned char
-bloomer_sha256_hash_struct = struct.Struct(b"<BB")
+# Little endian (<)
+# byte 0-3: hash iteration number for this layer, as an unsigned int
+# byte 4: layer number of this bloom filter, as an unsigned char
+bloomer_sha256_hash_struct = struct.Struct(b"<IB")
 
 # The version struct is a simple 2-byte short indicating version number
 # Little endian (<)


### PR DESCRIPTION
Matches up with the changes to rust-cascade in https://github.com/mozilla/rust-cascade/pull/22

Changes are:

- Don't put the hash algorithm in the top-level filter cascade header, as it's on each layer
- Move all python `struct` definitions and their enums to their own file, `fileformats.py`
- The hash iteration number has to be u32, not u8, because of how it was implemented in `rust-cascade`
- Fix a bug where the `salt` wasn't copied to the filters when they are constructed during `initialize`