### PR TITLE
Fix #16 and #17: Salts must be propagated, and reduce the min_filter_size #18 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,6 @@
     - id: filter-cascade-tests
       name: Tests for filter-cascade
       language: system
-      entry: python3 -m pytest .
+      entry: python3 -m pytest
       pass_filenames: false
       files: '.py$'

--- a/filtercascade/__init__.py
+++ b/filtercascade/__init__.py
@@ -284,7 +284,10 @@ class FilterCascade:
                 if self.filters[depth - 1].size < required_size:
                     # Resize filter
                     self.filters[depth - 1] = Bloomer.filter_with_characteristics(
-                        int(include_len * self.growth_factor), er, depth
+                        elements=int(include_len * self.growth_factor),
+                        falsePositiveRate=er,
+                        level=depth,
+                        hashAlg=self.defaultHashAlg,
                     )
                     log.info("Resized filter at {}-depth layer".format(depth))
             filter = self.filters[depth - 1]

--- a/filtercascade/__init__.py
+++ b/filtercascade/__init__.py
@@ -176,7 +176,8 @@ class Bloomer:
 class FilterCascade:
     def __init__(
         self,
-        filters,
+        filters=None,
+        *,
         error_rates=[0.02, 0.5],
         growth_factor=1.1,
         min_filter_length=10_000,
@@ -191,7 +192,7 @@ class FilterCascade:
             invertedLogic: If not supplied (or left as None), it will be auto-
                 detected.
         """
-        self.filters = filters
+        self.filters = filters or []
         self.error_rates = error_rates
         self.growth_factor = growth_factor
         self.min_filter_length = min_filter_length

--- a/filtercascade/test_filtercascade.py
+++ b/filtercascade/test_filtercascade.py
@@ -128,10 +128,15 @@ class TestFilterCascade(unittest.TestCase):
         f.initialize(include=small_set, exclude=iterator)
         self.assertFalse(f.invertedLogic)
 
-        self.assertEqual(len(f.filters), 3)
-        self.assertEqual(f.filters[0].size, 81272)
-        self.assertEqual(f.filters[1].size, 14400)
-        self.assertEqual(f.filters[2].size, 14400)
+        self.assertEqual(len(f.filters), 10)
+        self.assertEqual(
+            list(map(lambda x: x.size, f.filters)),
+            [26824, 10624, 2184, 5208, 1440, 1872, 1440, 1440, 1440, 1440],
+        )
+
+        h = MockFile()
+        f.tofile(h)
+        self.assertEqual(len(h), 6843)
 
     def test_verify_failure(self):
         """
@@ -390,11 +395,11 @@ class TestFilterCascadeSalts(unittest.TestCase):
         fc.initialize(include=small_set, exclude=iterator)
 
         self.assertEqual(len(fc.filters), 1)
-        self.assertEqual(fc.bitCount(), 81272)
+        self.assertEqual(fc.bitCount(), 8128)
 
         f = MockFile()
         fc.tofile(f)
-        self.assertEqual(len(f.data), 10182)
+        self.assertEqual(len(f.data), 1039)
 
     def test_fc_version_1_with_salt(self):
         with self.assertRaises(ValueError):
@@ -423,11 +428,11 @@ class TestFilterCascadeAlgorithms(unittest.TestCase):
         fc.initialize(include=small_set, exclude=iterator)
 
         self.assertEqual(len(fc.filters), 1)
-        self.assertEqual(fc.bitCount(), 81272)
+        self.assertEqual(fc.bitCount(), 8128)
 
         f = MockFile()
         fc.tofile(f)
-        self.assertEqual(len(f.data), 10173)
+        self.assertEqual(len(f.data), 1030)
 
         fc2 = filtercascade.FilterCascade.from_buf(f)
         iterator2, small_set2 = get_serial_iterator_and_set(num_iterator=10, num_set=1)

--- a/filtercascade/test_filtercascade.py
+++ b/filtercascade/test_filtercascade.py
@@ -80,7 +80,7 @@ class TestFilterCascade(unittest.TestCase):
         self.assertBloomerEqual(b1, b2)
 
     def test_fc_serial_deserial(self):
-        f1 = filtercascade.FilterCascade([])
+        f1 = filtercascade.FilterCascade()
         f1.initialize(exclude=["A", "B", "C"], include=["D"])
 
         h = MockFile()
@@ -90,15 +90,15 @@ class TestFilterCascade(unittest.TestCase):
         self.assertFilterCascadeEqual(f1, f2)
 
     def test_fc_input_types(self):
-        f1 = filtercascade.FilterCascade([])
+        f1 = filtercascade.FilterCascade()
         f1.initialize(include=["A"], exclude=["D"])
 
-        f2 = filtercascade.FilterCascade([])
+        f2 = filtercascade.FilterCascade()
         f2.initialize(include=[b"A"], exclude=[b"D"])
 
         incClass = SimpleToByteClass(ord("A"))
         excClass = SimpleToByteClass(ord("D"))
-        f3 = filtercascade.FilterCascade([])
+        f3 = filtercascade.FilterCascade()
         f3.initialize(include=[incClass], exclude=[excClass])
 
         self.assertTrue(incClass.method_called)
@@ -108,7 +108,7 @@ class TestFilterCascade(unittest.TestCase):
         self.assertFilterCascadeEqual(f1, f3)
 
     def test_fc_include_not_list(self):
-        f = filtercascade.FilterCascade([])
+        f = filtercascade.FilterCascade()
         with self.assertRaises(TypeError):
             f.initialize(
                 include=predictable_serial_gen(1), exclude=predictable_serial_gen(1)
@@ -120,7 +120,7 @@ class TestFilterCascade(unittest.TestCase):
             f.initialize(include=[], exclude=list(1))
 
     def test_fc_iterable(self):
-        f = filtercascade.FilterCascade([])
+        f = filtercascade.FilterCascade(filters=[])
 
         iterator, small_set = get_serial_iterator_and_set(
             num_iterator=500_000, num_set=3_000
@@ -139,7 +139,7 @@ class TestFilterCascade(unittest.TestCase):
         filter. Not every such change would raise an AssertionError,
         particularly on these small data-sets.
         """
-        fc = filtercascade.FilterCascade([])
+        fc = filtercascade.FilterCascade()
 
         iterator, small_set = get_serial_iterator_and_set(num_iterator=10, num_set=1)
         fc.initialize(include=small_set, exclude=iterator)
@@ -151,7 +151,7 @@ class TestFilterCascade(unittest.TestCase):
             fc.verify(include=small_set2, exclude=iterator2)
 
     def test_fc_load_version_1(self):
-        fc = filtercascade.FilterCascade([], version=1)
+        fc = filtercascade.FilterCascade(version=1)
         iterator, small_set = get_serial_iterator_and_set(num_iterator=10, num_set=1)
         fc.initialize(include=small_set, exclude=iterator)
 
@@ -162,7 +162,7 @@ class TestFilterCascade(unittest.TestCase):
         self.assertFilterCascadeEqual(fc, fc2)
 
     def test_fc_load_version_2(self):
-        fc = filtercascade.FilterCascade([], version=2)
+        fc = filtercascade.FilterCascade(version=2)
         iterator, small_set = get_serial_iterator_and_set(num_iterator=10, num_set=1)
         fc.initialize(include=small_set, exclude=iterator)
 
@@ -174,7 +174,6 @@ class TestFilterCascade(unittest.TestCase):
 
     def test_fc_load_version_2_with_salt(self):
         fc = filtercascade.FilterCascade(
-            [],
             version=2,
             salt=b"nacl",
             defaultHashAlg=filtercascade.fileformats.HashAlgorithm.SHA256,
@@ -214,7 +213,7 @@ class TestFilterCascade(unittest.TestCase):
             filtercascade.FilterCascade.from_buf(h)
 
     def test_fc_small_filter_length(self):
-        fc = filtercascade.FilterCascade([], min_filter_length=8)
+        fc = filtercascade.FilterCascade(min_filter_length=8)
 
         iterator, small_set = get_serial_iterator_and_set(
             num_iterator=5_000, num_set=100
@@ -229,7 +228,7 @@ class TestFilterCascade(unittest.TestCase):
         self.assertFilterCascadeEqual(fc, fc2)
 
     def test_fc_inverted_logic_iterators(self):
-        fc = filtercascade.FilterCascade([])
+        fc = filtercascade.FilterCascade()
         self.assertFalse(fc.invertedLogic)
 
         iterator, huge_set = get_serial_iterator_and_set(
@@ -239,7 +238,7 @@ class TestFilterCascade(unittest.TestCase):
             fc.initialize(include=huge_set, exclude=iterator)
 
     def test_fc_inverted_logic_automatic(self):
-        fc = filtercascade.FilterCascade([], min_filter_length=1024)
+        fc = filtercascade.FilterCascade(min_filter_length=1024)
         self.assertEqual(None, fc.invertedLogic)
 
         iterator, huge_set = get_serial_iterator_and_set(
@@ -269,7 +268,7 @@ class TestFilterCascade(unittest.TestCase):
         fc2.verify(include=huge_set, exclude=iterator)
 
     def test_fc_inverted_logic_explicit(self):
-        fc = filtercascade.FilterCascade([], invertedLogic=True)
+        fc = filtercascade.FilterCascade(invertedLogic=True)
         iterator, small_set = get_serial_iterator_and_set(num_iterator=2, num_set=2)
         fc.initialize(include=small_set, exclude=set(iterator))
         self.assertTrue(fc.invertedLogic)
@@ -285,7 +284,7 @@ class TestFilterCascade(unittest.TestCase):
 
     def test_fc_inverted_logic_disk_layout(self):
         fc = filtercascade.FilterCascade(
-            [], defaultHashAlg=filtercascade.fileformats.HashAlgorithm.SHA256, salt=b"a"
+            defaultHashAlg=filtercascade.fileformats.HashAlgorithm.SHA256, salt=b"a"
         )
         iterator, huge_set = get_serial_iterator_and_set(
             num_iterator=100, num_set=50_000
@@ -305,7 +304,7 @@ class TestFilterCascade(unittest.TestCase):
 
     def test_fc_standard_logic_disk_layout(self):
         fc = filtercascade.FilterCascade(
-            [], defaultHashAlg=filtercascade.fileformats.HashAlgorithm.SHA256, salt=b"a"
+            defaultHashAlg=filtercascade.fileformats.HashAlgorithm.SHA256, salt=b"a"
         )
         iterator, small_set = get_serial_iterator_and_set(
             num_iterator=50_000, num_set=100
@@ -371,22 +370,18 @@ class TestFilterCascadeSalts(unittest.TestCase):
     def test_non_byte_salt(self):
         with self.assertRaises(ValueError):
             filtercascade.FilterCascade(
-                [],
-                defaultHashAlg=filtercascade.fileformats.HashAlgorithm.SHA256,
-                salt=64,
+                defaultHashAlg=filtercascade.fileformats.HashAlgorithm.SHA256, salt=64,
             )
 
     def test_murmur_with_salt(self):
         with self.assertRaises(ValueError):
             filtercascade.FilterCascade(
-                [],
                 defaultHashAlg=filtercascade.fileformats.HashAlgorithm.MURMUR3,
                 salt=b"happiness",
             )
 
     def test_sha256_with_salt(self):
         fc = filtercascade.FilterCascade(
-            [],
             defaultHashAlg=filtercascade.fileformats.HashAlgorithm.SHA256,
             salt=b"happiness",
         )
@@ -404,14 +399,13 @@ class TestFilterCascadeSalts(unittest.TestCase):
     def test_fc_version_1_with_salt(self):
         with self.assertRaises(ValueError):
             filtercascade.FilterCascade(
-                [],
                 defaultHashAlg=filtercascade.fileformats.HashAlgorithm.SHA256,
                 salt=b"happiness",
                 version=1,
             )
 
     def test_expected_error_rates(self):
-        fc = filtercascade.FilterCascade([])
+        fc = filtercascade.FilterCascade()
         result = fc.set_crlite_error_rates(include_len=50, exclude_len=1_000)
         self.assertAlmostEqual(result[0], 0.0353, places=3)
         self.assertEqual(result[1], 0.5)
@@ -423,7 +417,7 @@ class TestFilterCascadeSalts(unittest.TestCase):
 
 class TestFilterCascadeAlgorithms(unittest.TestCase):
     def verify_minimum_sets(self, *, hashAlg):
-        fc = filtercascade.FilterCascade([], defaultHashAlg=hashAlg)
+        fc = filtercascade.FilterCascade(defaultHashAlg=hashAlg)
 
         iterator, small_set = get_serial_iterator_and_set(num_iterator=10, num_set=1)
         fc.initialize(include=small_set, exclude=iterator)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="filtercascade",
-    version="0.3.1",
+    version="0.4.0",
     description="A simple bloom filter cascade implementation in Python",
     long_description="A bloom filter cascade implementation in Python using the 32-bit variant of murmurhash3.",
     classifiers=[


### PR DESCRIPTION
This PR does a few things:

1. Salt propagation wasn't working for creation using `filter_with_characteristics`, which impacted both natural construction and the `from_buf` methods, fixing #16.
1. `filter_with_characteristics` is now marked deprecated
1. Filters are optional for the FilterCascade init method
1. Reduces the filter minimum size to 1,000 elements (down from 10,000) to reduce space, fixing #17.
1. Version bumps to 0.4.0

I experimented with more regarding #17, and it's definitely the case that one can iterate on the parameters and find a minimum solution, which might be desirable for some users and might be worth designing an automation tool to find. However, the current implementation matches the CRLite whitepaper and is best for the general case, so I only adjusted the minimum elements set.

If I remove the minimum elements portion, filters tend to get a very large number of layers quite quickly, which decreases efficiency. However, one can adjust the parameter `min_filter_length` down to even as low as `1` to experiment.