### PR TITLE
 Add specific exception handling around invalid error rates 

### DIFF
--- a/filtercascade/__init__.py
+++ b/filtercascade/__init__.py
@@ -147,6 +147,8 @@ class Bloomer:
 
     @classmethod
     def calc_n_hashes(cls, falsePositiveRate):
+        if falsePositiveRate < 0 or falsePositiveRate > 1:
+            raise InvalidErrorRateException(falsePositiveRate=falsePositiveRate)
         nHashes = math.ceil(math.log2(1.0 / falsePositiveRate))
         assert nHashes > 0, "Always must have a positive number of hashes"
         return nHashes

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="filtercascade",
-    version="0.4.0",
+    version="0.4.1",
     description="A simple bloom filter cascade implementation in Python",
     long_description="A bloom filter cascade implementation in Python using either the 32-bit variant of murmurhash3 or sha256.",
     classifiers=[


### PR DESCRIPTION
Error rates have to be between 0 and 1, exclusive, and values outside of that are invalid. This patch adds such checks, as well as some more test cases.

The exception message suggests the use of `set_crlite_error_rates`, which avoids invalid error rates by pre-checking whether the include and exclude sets require inverted logic -- the most common reason for things to go awry.

Version bumps to v0.4.1.